### PR TITLE
Tokens returned by Prism.tokenize() may have content which is an Array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,8 +52,9 @@ PrismDecorator.prototype.getDecorations = function(block) {
 
             this.highlighted[blockKey][tokenId] = token;
 
-            occupySlice(decorations, offset, offset + token.content.length, resultId);
-            offset += token.content.length;
+            var tokenLength = token.content instanceof Array ? token.content[0].length : token.content.length;
+            occupySlice(decorations, offset, offset + tokenLength, resultId);
+            offset += tokenLength;
         }
     }
 


### PR DESCRIPTION
Example: "class MyClass {}" in "java" syntax

Such a case is handled by assuming that the array will always contain one element (this assumption is simply based on observations. A more thorough understanding will require looking to Prismjs code)

Fix for issue https://github.com/SamyPesse/draft-js-prism/issues/10
