### PR TITLE
Allow the decorator to work if there are nested tokens

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,8 +52,8 @@ PrismDecorator.prototype.getDecorations = function(block) {
 
             this.highlighted[blockKey][tokenId] = token;
 
-            occupySlice(decorations, offset, offset + token.content.length, resultId);
-            offset += token.content.length;
+            occupySlice(decorations, offset, offset + token.matchedStr.length, resultId);
+            offset += token.matchedStr.length;
         }
     }
 


### PR DESCRIPTION
A token can have other tokens in it's content.  This does not do the
parsing of them, but it does make the length of the content be correct.
