### PR TITLE
Allow overriding Prism module with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ### Installation
 
 ```
-$ npm install draft-js-prism
+$ npm install draft-js-prism prismjs
 ```
 
 ### Usage
@@ -18,12 +18,15 @@ $ npm install draft-js-prism
 ```js
 var Draft = require('draft-js');
 var PrismDecorator = require('draft-js-prism');
+var Prism = require('prismjs')
 
-var decorator = new PrismDecorator();
+var decorator = new PrismDecorator({
+  // Provide your own instance of PrismJS
+  prism: Prism,
+});
 var editorState = Draft.EditorState.createEmpty(decorator)
 ```
 
 You'll also need to include the css for one of the [Prism themes](https://github.com/PrismJS/prism/tree/gh-pages/themes).
 
 You can use this decorator combined with others by using [draft-js-multidecorators](https://github.com/SamyPesse/draft-js-multidecorators)
-

--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -1,5 +1,6 @@
 var Draft = require('draft-js');
 var expect = require('expect');
+var Prism = require('prismjs');
 
 var PrismDecorator = require('../');
 
@@ -10,7 +11,9 @@ describe('PrismDecorator', function() {
     });
 
     it('should not fail for block without syntax', function() {
-        var decorator = new PrismDecorator();
+        var decorator = new PrismDecorator({
+          prism: Prism,
+        });
         var out = decorator.getDecorations(jsBlock);
         expect(out.toJS()).toEqual([
             null, null, null, null, null, null, null, null,
@@ -20,6 +23,7 @@ describe('PrismDecorator', function() {
 
     it('should use defaultSyntax option', function() {
         var decorator = new PrismDecorator({
+            prism: Prism,
             defaultSyntax: 'javascript'
         });
         var out = decorator.getDecorations(jsBlock);
@@ -36,6 +40,7 @@ describe('PrismDecorator', function() {
             text: 'var'
         });
         var decorator = new PrismDecorator({
+            prism: Prism,
             defaultSyntax: 'javascript'
         });
         var out = decorator.getDecorations(block);
@@ -44,4 +49,3 @@ describe('PrismDecorator', function() {
         ]);
     });
 });
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var Immutable = require('immutable');
-var Prism = require('prismjs');
 
 var PrismOptions = require('./options');
 
@@ -23,6 +22,7 @@ PrismDecorator.prototype.getDecorations = function(block) {
     var blockKey = block.getKey();
     var blockText = block.getText();
     var decorations = Array(blockText.length).fill(null);
+    var Prism = this.options.get('prism');
 
     this.highlighted[blockKey] = {};
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,4 +1,5 @@
 var Immutable = require('immutable');
+var Prism = require('prismjs');
 var React = require('react');
 var extend = require('extend');
 
@@ -55,7 +56,10 @@ var PrismOptions = Immutable.Record({
     getSyntax:          defaultGetSyntax,
 
     // Render a decorated text for a token
-    render:             defaultRender
+    render:             defaultRender,
+
+    // Prism module
+    prism:              Prism
 });
 
 module.exports = PrismOptions;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "homepage": "https://github.com/SamyPesse/draft-js-prism#readme",
   "dependencies": {
     "extend": "^3.0.0",
-    "immutable": "*",
-    "prismjs": "^1.5.0"
+    "immutable": "*"
+  },
+  "peerDependencies": {
+    "prismjs": "1.x"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",
@@ -40,6 +42,7 @@
     "http-server": "^0.9.0",
     "mocha": "^2.5.3",
     "parallelshell": "2.0.0",
+    "prismjs": "1.x",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "watch": "^0.18.0"


### PR DESCRIPTION
Hi,

I've added an option to override Prism module to use in the decorator.

I wanted this feature to customized Prism module with plugins and components.

```js
import PrismDecorator from 'draft-js-prism';
import Prism from 'prismjs';
import 'prismjs/components/prism-java';
import 'prismjs/components/prism-scala';
import 'prismjs/components/prism-go';
import 'prismjs/components/prism-sql';
import 'prismjs/components/prism-bash';
import 'prismjs/components/prism-c';
import 'prismjs/components/prism-cpp';
import 'prismjs/components/prism-kotlin';
import 'prismjs/components/prism-perl';
import 'prismjs/components/prism-ruby';
import 'prismjs/components/prism-swift';

const decorators = [new PrismDecorator({
  prism: Prism
})];

// ...
```