### PR TITLE
Support arbitrary levels of tokens (e.g. "markup" generates these)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,14 +17,15 @@ function PrismDecorator(options) {
  * @return {List<String>}
  */
 PrismDecorator.prototype.getDecorations = function(block) {
-    var tokens, token, tokenId, resultId, offset = 0;
+    var tokens, token, tokenId, resultId, offset = 0, tokenCount = 0;
     var filter = this.options.get('filter');
     var getSyntax = this.options.get('getSyntax');
     var blockKey = block.getKey();
     var blockText = block.getText();
     var decorations = Array(blockText.length).fill(null);
+    var highlighted = this.highlighted;
 
-    this.highlighted[blockKey] = {};
+    highlighted[blockKey] = {};
 
     if (!filter(block)) {
         return Immutable.List(decorations);
@@ -41,20 +42,29 @@ PrismDecorator.prototype.getDecorations = function(block) {
     var grammar = Prism.languages[syntax];
     tokens = Prism.tokenize(blockText, grammar);
 
+
+    function processToken(decorations, token, offset) {
+      if (typeof token === 'string') {
+        return
+      }
+      //First write this tokens full length
+      tokenId = 'tok'+(tokenCount++);
+      resultId = blockKey + '-' + tokenId;
+      highlighted[blockKey][tokenId] = token;
+      occupySlice(decorations, offset, offset + token.length, resultId);
+      //Then recurse through the child tokens, overwriting the parent
+      var childOffset = offset;
+      for (var i =0; i < token.content.length; i++) {
+        var childToken = token.content[i];
+        processToken(decorations, childToken, childOffset);
+        childOffset += childToken.length;
+      }
+    }
+
     for (var i =0; i < tokens.length; i++) {
         token = tokens[i];
-
-        if (typeof token === 'string') {
-            offset += token.length;
-        } else {
-            tokenId = 'tok'+offset;
-            resultId = blockKey + '-' + tokenId;
-
-            this.highlighted[blockKey][tokenId] = token;
-
-            occupySlice(decorations, offset, offset + token.content.length, resultId);
-            offset += token.content.length;
-        }
+        processToken(decorations, token, offset);
+        offset += token.length;
     }
 
     return Immutable.List(decorations);


### PR DESCRIPTION
#14 and #11 fix some issues with nested tokens, but these didn't support the output of "markup". To really deal with the output from prism you need to recurse through the child tokens.