### PR TITLE
JS template-string coverage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,11 +61,16 @@ PrismDecorator.prototype.getDecorations = function(block) {
       }
     }
 
-    for (var i =0; i < tokens.length; i++) {
-        token = tokens[i];
+    var moveTokensToDecorations = tokensList => tokensList.forEach(token => {
+      if (Array.isArray(token.content)) {
+        moveTokensToDecorations(token.content);
+      } else {
         processToken(decorations, token, offset);
         offset += token.length;
-    }
+      }
+    });
+
+    moveTokensToDecorations(tokens);
 
     return Immutable.List(decorations);
 };


### PR DESCRIPTION
Hi, in some cases token could contain not string as a `content`, but an array with internal tokens. Could be tested with js template-string.