### PR TITLE
bugfix: token in getPropsForKey can be undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ PrismDecorator.prototype.getPropsForKey = function(key) {
     var token = this.highlighted[blockKey][tokId];
 
     return {
-        type: token.type
+        type: token && token.type
     };
 };
 


### PR DESCRIPTION
I use draft.js and when user types "&nbsp;" and then "Ctrl + z" the whole page crashes with an error

```
TypeError: Cannot read property 'type' of undefined
    at a.getPropsForKey 
```